### PR TITLE
remove percent mulitplier from absolute normal mde calc

### DIFF
--- a/R/utils_power_normal.R
+++ b/R/utils_power_normal.R
@@ -299,12 +299,20 @@ construct_text_pow_norm_mde <-
 
     mde_calc <-
       solve_power_all_pair_norm_mde(base_mean, base_sd, samp_prop, tot_ss, eff_type, sig, pow, pairs)
+
+    if(eff_type == 'abs'){
+      formatted_mde_calc = mde_calc
+    } else {
+      formatted_mde_calc = mde_calc * 100
+    }
+    
     string_ret <-
       HTML(paste0('With a total sample size of ', tot_ss,
                   ', distributed across the treatments (in the given proportions), your will be able to estimate a ',
-                  signif(mde_calc * 100, 3), '% increase in the outcome with ',
+                  signif(formatted_mde_calc, 3), '% increase in the outcome with ',
                   pow * 100, '% power and ', signif(sig * 100, 2), '% significance.'
       ))
+      
     return(string_ret)
   }
 


### PR DESCRIPTION
The normal MDE calculator currently returns a percent rather than an absolute value for the "Absolute Effect" selection box. This change keeps the percent for relative MDE calcs but removes it for absolute calcs. Note that the relative effect is `8.97%` which is an absolute effect of `0.448` (it's been a while since I've written with R, best double check it works properly).

<img width="1467" alt="Screenshot 2025-03-05 at 5 58 37 pm" src="https://github.com/user-attachments/assets/6b080a71-6c66-48cd-bc50-9f7feb776db0" />
